### PR TITLE
fix: Add output configuration for Vercel deployment

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  output: 'standalone',
+}
 
 module.exports = nextConfig


### PR DESCRIPTION
Fixes #4 

## Summary
Added `output: 'standalone'` to next.config.js to fix the missing routes-manifest.json error during Vercel deployment.

## Changes
- Updated next.config.js with proper output configuration

Generated with [Claude Code](https://claude.ai/code)