### PR TITLE
fix: Vercelデプロイエラーを修正

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  output: 'standalone',
-}
+const nextConfig = {}
 
 module.exports = nextConfig


### PR DESCRIPTION
# 概要

Vercelでのデプロイ時に`routes-manifest.json`が見つからないエラーを修正しました。

## 変更内容
- `next.config.js`から`output: 'standalone'`設定を削除
- Vercelが期待する標準的なNext.jsビルド出力に戻しました

Resolves #6

Generated with [Claude Code](https://claude.ai/code)