### PR TITLE
fix: Add OpenAI to apiMetadata to enable documentation page generation

### DIFF
--- a/lib/api-content.ts
+++ b/lib/api-content.ts
@@ -27,6 +27,10 @@ const apiMetadata: Record<string, { name: string; description: string }> = {
   supabase: {
     name: 'Supabase',
     description: 'Backend as a Service'
+  },
+  openai: {
+    name: 'OpenAI',
+    description: 'AI models and APIs'
   }
 }
 


### PR DESCRIPTION
Fixes #12 - 未実装？

The OpenAI API documentation was present in the sidebar but inaccessible because OpenAI was missing from the apiMetadata object. This caused getAvailableApis() to exclude OpenAI when generating static paths, resulting in 404 errors.

This PR adds OpenAI to apiMetadata, allowing the OpenAI documentation page to be properly generated and accessible in the deployed application.

Generated with [Claude Code](https://claude.ai/code)